### PR TITLE
Revert "add runtime and transform"

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ module.exports = function (babel, args) {
       browsers: args.browsers || '> 2% in US',
     };
     config.presets[0][1].modules = false;
-    config.plugins.push('transform-runtime');
     if (env === 'development') {
       try {
         require('react-hot-loader/babel');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-object-entries": "^1.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.1.11",
     "babel-preset-react": "^6.23.0",
     "babel-preset-react-optimize": "^1.0.1",


### PR DESCRIPTION
This reverts commit dde929a527a5947407ec588c12dfa906ed717f83.

Removed because there is simply too much variation on how ESM code is
built and expected to work between our first and third party code.