### PR TITLE
Remove babel-preset-react-optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ module.exports = function (babel, args) {
         );
       }
     }
-    if (env === 'production') {
-      config.presets.push('react-optimize');
-    }
   } else {
     config.plugins.push(['css-modules-transform', {
       generateScopedName: '[name]__[local]___[hash:base64:5]',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.1.11",
     "babel-preset-react": "^6.23.0",
-    "babel-preset-react-optimize": "^1.0.1",
     "fast-async": "^6.2.1"
   },
   "homepage": "https://github.com/gas-buddy/babel-preset-gasbuddy#readme"


### PR DESCRIPTION
The `babel-preset-react-optimize` preset doesn't reduce the size of our bundles. [Documentation](https://github.com/jamiebuilds/babel-react-optimize) seems to indicate that it will only alter the output of your transpiled React components, so I'm not seeing the value added. I'm proposing we remove it as the first of a few improvements to this preset. If rejected, I can at least learn why we had it in the first place.