### PR TITLE
Update our Babel config to take advantage of Babel 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (api, options) {
     },
   };
 
-  if (api.env(['development'])) {
+  if (api.env('development')) {
     config.plugins.push('react-hot-loader/babel');
   }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = function (babel, args) {
       '@babel/preset-react',
     ],
     plugins: [
+      ['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
       '@babel/plugin-transform-flow-strip-types',
       '@babel/plugin-proposal-class-properties',
       '@babel/plugin-proposal-optional-chaining',
@@ -31,8 +32,7 @@ module.exports = function (babel, args) {
   };
 
   if (isWebpack) {
-    config.plugins.unshift(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
-      ['module:fast-async', { spec: true }]);
+    config.plugins.unshift(['module:fast-async', { spec: true }]);
     Object.assign(config.presets[0][1], {
       targets: args.browsers || '> 2% in US',
       modules: false,
@@ -61,7 +61,6 @@ module.exports = function (babel, args) {
     config.plugins.push(['babel-plugin-css-modules-transform', {
       generateScopedName: '[name]__[local]___[hash:base64:5]',
     }]);
-    config.plugins.push(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }]);
     if (env === 'test') {
       config.plugins.unshift('istanbul');
     }

--- a/index.js
+++ b/index.js
@@ -33,14 +33,13 @@ module.exports = function (babel, args) {
   if (isWebpack) {
     config.plugins.unshift(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
       ['module:fast-async', { spec: true }]);
-    config.presets[0][1].targets = {
-      browsers: args.browsers || '> 2% in US',
-    };
     Object.assign(config.presets[0][1], {
+      targets: {
+        browsers: args.browsers || '> 2% in US',
+      },
       modules: false,
       useBuiltIns: 'usage',
     });
-    config.presets[0][1].modules = false;
     if (env === 'development') {
       try {
         require('react-hot-loader/babel');

--- a/index.js
+++ b/index.js
@@ -1,17 +1,7 @@
-/* global module */
-/**
- * NOTE: This may have to change in babel@7. To wit:
- * loganfsmyth [3:20 PM]
- * the point is, a preset function in 6.x is executed every time a file is compiled, in 7.x
- * we will try to reexecute them less often, so if you depend on potentially mutable state,
- * you'll have to give babel a way to know when that state changes. Using `env` will do that
- * automatically, but if you check a global yourself you'll need to handle that, once 7.x
- * lands anyway
- *
- * Will need to add something like: api.cache(() => process.env.WEBPACK_BROWSER_TARGET || '')
- */
-module.exports = function (babel, args) {
-  const isWebpack = (args && args.webpack);
+module.exports = function (api, options) {
+  api.assertVersion(7);
+
+  const isWebpack = (options && options.webpack);
   const env = process.env.NODE_ENV || 'development';
 
   const config = {
@@ -29,41 +19,40 @@ module.exports = function (babel, args) {
       '@babel/plugin-proposal-class-properties',
       '@babel/plugin-proposal-optional-chaining',
     ],
+    env: {
+      browser: {
+        presets: [
+          ['@babel/preset-env', {
+            targets: options.browsers || '> 2% in US',
+            modules: false,
+            useBuiltIns: 'usage',
+          }],
+        ],
+        plugins: [
+          ['module:fast-async', { spec: true }],
+          '@babel/plugin-transform-react-constant-elements',
+          '@babel/plugin-transform-react-inline-elements',
+          'babel-plugin-transform-react-remove-prop-types',
+          'babel-plugin-transform-react-class-to-function',
+        ],
+      },
+      webserver: {
+        presets: [
+          // We don't want this in config by default in case you're compiling ES modules
+          ['babel-plugin-css-modules-transform', {
+            generateScopedName: '[name]__[local]___[hash:base64:5]',
+          }],
+        ],
+      },
+    },
   };
 
-  if (isWebpack) {
-    config.plugins.unshift(['module:fast-async', { spec: true }]);
-    Object.assign(config.presets[0][1], {
-      targets: args.browsers || '> 2% in US',
-      modules: false,
-      useBuiltIns: 'usage',
-    });
-    if (env === 'development') {
-      try {
-        require('react-hot-loader/babel');
-        config.plugins.unshift('react-hot-loader/babel');
-      } catch (error) {
-        console.log(
-          'babel-preset-gasbuddy requires react-hot-loader@^3.0.0-beta.6 for hot load support.\n',
-          'Please add a dev only dependency to your project if you want hot loader support.'
-        );
-      }
-    }
-    if (env === 'production') {
-      config.plugins.push(
-        '@babel/plugin-transform-react-constant-elements',
-        '@babel/plugin-transform-react-inline-elements',
-        'babel-plugin-transform-react-remove-prop-types',
-        'babel-plugin-transform-react-class-to-function',
-      );
-    }
-  } else {
-    config.plugins.push(['babel-plugin-css-modules-transform', {
-      generateScopedName: '[name]__[local]___[hash:base64:5]',
-    }]);
-    if (env === 'test') {
-      config.plugins.unshift('istanbul');
-    }
+  if (api.env(['development'])) {
+    config.plugins.push('react-hot-loader/babel');
+  }
+
+  if (api.env('test')) {
+    config.plugins.push('istanbul');
   }
 
   return config;

--- a/index.js
+++ b/index.js
@@ -34,9 +34,7 @@ module.exports = function (babel, args) {
     config.plugins.unshift(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
       ['module:fast-async', { spec: true }]);
     Object.assign(config.presets[0][1], {
-      targets: {
-        browsers: args.browsers || '> 2% in US',
-      },
+      targets: args.browsers || '> 2% in US',
       modules: false,
       useBuiltIns: 'usage',
     });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "fast-async": "^6.3.8",
     "find-root": "^1.1.0"
   },
+  "peerDependencies": {
+    "react-hot-loader": "^4.x"
+  },
   "engines": {
     "node": ">=8.9"
   },


### PR DESCRIPTION
**This is an extension to #6 and includes breaking changes.** It also requires an update to our `web-dev` package. Browser builds will require `BABEL_ENV=browser` to be set for a Webpack build. Building React-rendering servers will require `BABEL_ENV=webserver`.

### Why?
To simplify. I believe this is easier to read. It also simplifies usability. Our Webpack configuration intentionally [disables](https://github.com/gas-buddy/web-dev/blob/master/src/webpack/config.js#L68-L77) the use of a `.babelrc` file and sets it's own configuration for `babel-loader`. Instead, I'd like to see our Webpack configuration just work without requiring additional Babel configuration.

Assert the version so that projects using our config are using Babel 7+.

Also, we're currently loading the `babel-plugin-css-modules-transform` plugin in all scenarios. When we build ES modules, we do not want the CSS imports to be transpiled, so we'd like to remove it from the standard config.

Lastly, the recent update to Babel 7 has allowed support for merging plugin and preset configurations using the `env` property. Previously they were not merged and would overwrite each other, which was not ideal.