### PR TITLE
Move conditional babel config to env prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,15 +55,16 @@ module.exports = function (api, options) {
           }],
         ],
       },
+      test: {
+        plugins: [
+          'istanbul'
+        ],
+      }
     },
   };
 
   if (api.env('development')) {
     config.plugins.push('react-hot-loader/babel');
-  }
-
-  if (api.env('test')) {
-    config.plugins.push('istanbul');
   }
 
   return config;

--- a/index.js
+++ b/index.js
@@ -13,9 +13,6 @@
 module.exports = function (api, options) {
   api.assertVersion(7);
 
-  const isWebpack = (options && options.webpack);
-  const env = process.env.NODE_ENV || 'development';
-
   const config = {
     sourceMaps: true,
     presets: [

--- a/index.js
+++ b/index.js
@@ -28,46 +28,40 @@ module.exports = function (babel, args) {
       '@babel/plugin-proposal-class-properties',
       '@babel/plugin-proposal-optional-chaining',
     ],
+    env: {
+      browser: {
+        presets: [
+          ['@babel/preset-env', {
+            targets: options.browsers || '> 2% in US',
+            modules: false,
+            useBuiltIns: 'usage',
+          }],
+        ],
+        plugins: [
+          ['module:fast-async', { spec: true }],
+          '@babel/plugin-transform-react-constant-elements',
+          '@babel/plugin-transform-react-inline-elements',
+          'babel-plugin-transform-react-remove-prop-types',
+          'babel-plugin-transform-react-class-to-function',
+        ],
+      },
+      webserver: {
+        presets: [
+          // We don't want this in config by default in case you're compiling ES modules
+          ['babel-plugin-css-modules-transform', {
+            generateScopedName: '[name]__[local]___[hash:base64:5]',
+          }],
+        ],
+      },
+    },
   };
 
-  if (isWebpack) {
-    config.plugins.unshift(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
-      ['module:fast-async', { spec: true }]);
-    config.presets[0][1].targets = {
-      browsers: args.browsers || '> 2% in US',
-    };
-    Object.assign(config.presets[0][1], {
-      modules: false,
-      useBuiltIns: 'usage',
-    });
-    config.presets[0][1].modules = false;
-    if (env === 'development') {
-      try {
-        require('react-hot-loader/babel');
-        config.plugins.unshift('react-hot-loader/babel');
-      } catch (error) {
-        console.log(
-          'babel-preset-gasbuddy requires react-hot-loader@^3.0.0-beta.6 for hot load support.\n',
-          'Please add a dev only dependency to your project if you want hot loader support.'
-        );
-      }
-    }
-    if (env === 'production') {
-      config.plugins.push(
-        '@babel/plugin-transform-react-constant-elements',
-        '@babel/plugin-transform-react-inline-elements',
-        'babel-plugin-transform-react-remove-prop-types',
-        'babel-plugin-transform-react-class-to-function',
-      );
-    }
-  } else {
-    config.plugins.push(['babel-plugin-css-modules-transform', {
-      generateScopedName: '[name]__[local]___[hash:base64:5]',
-    }]);
-    config.plugins.push(['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }]);
-    if (env === 'test') {
-      config.plugins.unshift('istanbul');
-    }
+  if (api.env('development')) {
+    config.plugins.push('react-hot-loader/babel');
+  }
+
+  if (api.env('test')) {
+    config.plugins.push('istanbul');
   }
 
   return config;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
 module.exports = function (api, options) {
   api.assertVersion(7);
 
-  const config = {
+  return {
     sourceMaps: true,
     presets: [
       ['@babel/preset-env', {
@@ -54,15 +54,12 @@ module.exports = function (api, options) {
       },
       test: {
         plugins: [
-          'istanbul'
+          'istanbul',
         ],
+      },
+      development: {
+        plugins: ['react-hot-loader/babel'],
       }
     },
   };
-
-  if (api.env('development')) {
-    config.plugins.push('react-hot-loader/babel');
-  }
-
-  return config;
 }


### PR DESCRIPTION
This includes breaking changes.

Setting `BABEL_ENV=browser` will tell Babel to
- Target browsers instead of Node
- Transform React components
- Transform async/await commands

Setting `BABEL_ENV=webserver` will tell Babel to
- Convert CSS imports into class name maps (useful for server-rendering)

This will allow us to change our Webpack configuration from
```javascript
{
  test: /\.js$/,
  // This is necessary to get the babel-polyfill to be minimized
  exclude: ignore,
  use: [
    {
      loader: 'babel-loader',
      options: {
        babelrc: false,
        presets: [
          // I don't love that this is hardcoded as opposed to reading from .babelrc
          ['gasbuddy', {
            webpack: true,
            browsers: process.env.BROWSER_SUPPORT,
          }],
        ],
      },
    },
  ],
}
```
to
```javasscript
{
  test: /\.js$/,
  // This is necessary to get the babel-polyfill to be minimized
  exclude: ignore,
  use: [
    'babel-loader',
  ],
}
```