### PR TITLE
ci: adopt npm OIDC trusted publishing with dist-tag derivation

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -18,14 +22,18 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
+      - name: Publish
+        run: |
+          NPM_TAG=$(node -p "require('./package.json').version.split('-')[1]?.split('.')[0] || 'latest'")
+          echo "Publishing with dist-tag: $NPM_TAG"
+          npm publish --tag "$NPM_TAG"


### PR DESCRIPTION
## Summary

- Replaces the long-lived `NPM_TOKEN` secret in `.github/workflows/npmpublish.yml`'s publish step with npm's OIDC trusted publishing — GitHub mints a short-lived token per run, npm exchanges it for publish rights, and there's no shared secret to rotate or leak.
- Adds correct dist-tag derivation (`npm publish --tag "$NPM_TAG"`, derived from the version's pre-release identifier), so a future pre-release version (e.g. `1.2.0-beta.0`) publishes under `beta` instead of silently taking `latest`. Today's `6.0.0` still resolves to `latest`.
- Scopes `id-token: write` to the `publish-npm` job only (workflow-level `permissions: {}`, `build` job gets `contents: read` only) — a workflow-level grant would hand OIDC-mint rights to the build job too, which static-analysis tooling (zizmor, Arnica) flags.
- Bumps the publish job's Node version from 10 to **24** (build job's Node 10 is unchanged — this PR only touches publish auth, not the test matrix). Node 24 bundles npm ≥11.6, which is required for npm's OIDC trusted-publishing support; Node 22's bundled npm (10.9.x) is below that floor, so no `npx`-pinned npm override is needed on Node 24.
- `npm ci` in both jobs needs no credential — every dependency in `package.json` is a public, unscoped package.

## Required manual step (blocks this from working until done)

This workflow change alone does nothing until a trusted publisher is registered on npmjs.com for this package (npm org admin required):

- **Organization/user**: `gas-buddy`
- **Repository**: `babel-preset-gasbuddy`
- **Workflow filename**: `npmpublish.yml`
- **Environment**: none (the workflow doesn't declare one)

## Verification

`permissions`/`env` shape (skill's yaml assertion script):
```
workflow perms (want {}): {}
build perms: {'contents': 'read'}
  actions/checkout@v1 | env: []
  actions/setup-node@v1 | env: []
  None | env: []
publish-npm perms: {'id-token': 'write', 'contents': 'read'}
  actions/checkout@v1 | env: []
  actions/setup-node@v1 | env: []
  None | env: []
  Publish | env: []
```
No `env` block anywhere — `NODE_AUTH_TOKEN`/`NPM_AUTH_TOKEN` and any `npm config set ..._authToken` are fully removed (`grep -iE "authToken|NPM_TOKEN|npm config set"` on the file returns nothing).

Dist-tag derivation checked against real version shapes on Node 24 (the version the publish job runs):
| Version | Derived tag |
|---|---|
| `1.2.0-beta.0` | `beta` |
| `1.2.0-rc.1` | `rc` |
| `1.2.0-alpha` | `alpha` |
| `2.0.0-next.12` | `next` |
| `1.2.0` | `latest` |
| `6.0.0` (current) | `latest` |
| `5.1.0-0` | `0` (npm itself rejects this at publish time — no guard needed) |

`npm ci` verified working under Node 24/npm 11.16.0 against the existing lockfile with no changes to tracked files.

## Test plan

- [ ] Org admin registers the npmjs.com trusted publisher (org `gas-buddy`, repo `babel-preset-gasbuddy`, workflow `npmpublish.yml`, no environment)
- [ ] Merge and confirm the next push to `master` publishes without any `NPM_TOKEN` secret present, and the run log shows `npm notice Publishing to https://registry.npmjs.org/ with tag latest` with no auth-config step preceding it
- [ ] `npm dist-tag ls babel-preset-gasbuddy` still shows `latest` pointing at the current released version after the first OIDC-based publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhC6j8cuzojoCMzpBVT5zL
